### PR TITLE
wip: kick off routing and basic view structure

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,9 +25,11 @@ module.exports = {
     '@typescript-eslint',
   ],
   rules: {
+    'react/jsx-props-no-spreading': 0,
     'react/jsx-filename-extension': [1, { 'extensions': ['.tsx'] }],
     'import/extensions': [1, { 'extensions': ['.js', '.jsx',  '.ts', '.tsx', '.json']}],
     'import/no-extraneous-dependencies': ['error', {'devDependencies': true}],
+    '@typescript-eslint/no-unused-vars': [2, { args: 'none' }],
     'react/jsx-one-expression-per-line': 0
   },
   settings: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1854,6 +1854,11 @@
         "@types/node": "*"
       }
     },
+    "@types/history": {
+      "version": "4.7.5",
+      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.5.tgz",
+      "integrity": "sha512-wLD/Aq2VggCJXSjxEwrMafIP51Z+13H78nXIX0ABEuIGhmB5sNGbR113MOKo+yfw+RDo1ZU3DM6yfnnRF/+ouw=="
+    },
     "@types/hoist-non-react-statics": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
@@ -1951,9 +1956,10 @@
       }
     },
     "@types/react-native": {
-      "version": "0.61.17",
-      "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.61.17.tgz",
-      "integrity": "sha512-12qKZz/ob56lglVRAIDgqDchcyO0g5lZtrjxCTQDNJv8HFHZMcZx78+/CjKsu3LGs6KbajkZ1+0htqiaxr5JVA==",
+      "version": "0.61.18",
+      "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.61.18.tgz",
+      "integrity": "sha512-2uBfNTgzOe29Y8VluLwn0PIi2jbXHewJ5NNaJie0UsCtUr9QZqmS78Qmp6VXpxDSosB7gF7GMObFLmi8J1fZgg==",
+      "dev": true,
       "requires": {
         "@types/react": "*"
       }
@@ -1969,6 +1975,25 @@
         "redux": "^4.0.0"
       }
     },
+    "@types/react-router": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.4.tgz",
+      "integrity": "sha512-PZtnBuyfL07sqCJvGg3z+0+kt6fobc/xmle08jBiezLS8FrmGeiGkJnuxL/8Zgy9L83ypUhniV5atZn/L8n9MQ==",
+      "requires": {
+        "@types/history": "*",
+        "@types/react": "*"
+      }
+    },
+    "@types/react-router-dom": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.1.3.tgz",
+      "integrity": "sha512-pCq7AkOvjE65jkGS5fQwQhvUp4+4PVD9g39gXLZViP2UqFiFzsEpB3PKf0O6mdbKsewSK8N14/eegisa/0CwnA==",
+      "requires": {
+        "@types/history": "*",
+        "@types/react": "*",
+        "@types/react-router": "*"
+      }
+    },
     "@types/stack-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
@@ -1979,6 +2004,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@types/styled-components/-/styled-components-5.0.1.tgz",
       "integrity": "sha512-1yRYO1dAE2MGEuYKF1yQFeMdoyerIQn6ZDnFFkxZamcs3rn8RQVn98edPsTROAxbTz81tqnVN4BJ3Qs1cm/tKg==",
+      "dev": true,
       "requires": {
         "@types/hoist-non-react-statics": "*",
         "@types/react": "*",
@@ -6135,6 +6161,11 @@
       "dev": true,
       "optional": true
     },
+    "gud": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
+      "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
+    },
     "handle-thing": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.0.tgz",
@@ -6227,6 +6258,19 @@
       "requires": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
+      }
+    },
+    "history": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
+      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "loose-envify": "^1.2.0",
+        "resolve-pathname": "^3.0.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0",
+        "value-equal": "^1.0.1"
       }
     },
     "hmac-drbg": {
@@ -9342,6 +9386,16 @@
       "integrity": "sha1-z8RcN+nsDY8KDsPdTvf3w6vjklY=",
       "dev": true
     },
+    "mini-create-react-context": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.3.2.tgz",
+      "integrity": "sha512-2v+OeetEyliMt5VHMXsBhABoJ0/M4RCe7fatd/fBy6SMiKazUSEt3gxxypfnk2SHMkdBYvorHRoQxuGoiwbzAw==",
+      "requires": {
+        "@babel/runtime": "^7.4.0",
+        "gud": "^1.0.0",
+        "tiny-warning": "^1.0.2"
+      }
+    },
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -10730,6 +10784,52 @@
         "react-is": "^16.9.0"
       }
     },
+    "react-router": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.1.2.tgz",
+      "integrity": "sha512-yjEuMFy1ONK246B+rsa0cUam5OeAQ8pyclRDgpxuSCrAlJ1qN9uZ5IgyKC7gQg0w8OM50NXHEegPh/ks9YuR2A==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "history": "^4.9.0",
+        "hoist-non-react-statics": "^3.1.0",
+        "loose-envify": "^1.3.1",
+        "mini-create-react-context": "^0.3.0",
+        "path-to-regexp": "^1.7.0",
+        "prop-types": "^15.6.2",
+        "react-is": "^16.6.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "path-to-regexp": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
+    },
+    "react-router-dom": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.1.2.tgz",
+      "integrity": "sha512-7BPHAaIwWpZS074UKaw1FjVdZBSVWEk8IuDXdB+OkLb8vd/WRQIpA4ag9WQk61aEfQs47wHyjWUoUGGZxpQXew==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "history": "^4.9.0",
+        "loose-envify": "^1.3.1",
+        "prop-types": "^15.6.2",
+        "react-router": "5.1.2",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
+      }
+    },
     "react-test-renderer": {
       "version": "16.13.0",
       "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.13.0.tgz",
@@ -11179,6 +11279,11 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true
+    },
+    "resolve-pathname": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
+      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -12592,6 +12697,16 @@
         "setimmediate": "^1.0.4"
       }
     },
+    "tiny-invariant": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
+      "integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw=="
+    },
+    "tiny-warning": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -13099,6 +13214,11 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "value-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
+      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@babel/preset-react": "^7.8.3",
     "@babel/preset-typescript": "^7.8.3",
     "@types/enzyme-adapter-react-16": "^1.0.6",
+    "@types/styled-components": "^5.0.1",
     "@typescript-eslint/eslint-plugin": "^2.21.0",
     "@typescript-eslint/parser": "^2.21.0",
     "babel-plugin-styled-components": "^1.10.7",
@@ -55,12 +56,13 @@
     "@types/react": "^16.9.23",
     "@types/react-dom": "^16.9.5",
     "@types/react-redux": "^7.1.7",
-    "@types/styled-components": "^5.0.1",
+    "@types/react-router-dom": "^5.1.3",
     "babel-loader": "^8.0.6",
     "jest-styled-components": "^7.0.0",
     "react": "^16.13.0",
     "react-dom": "^16.13.0",
     "react-redux": "^7.2.0",
+    "react-router-dom": "^5.1.2",
     "redux": "^4.0.5",
     "styled-components": "^5.0.1",
     "webpack-dev-server": "^3.10.3"
@@ -70,5 +72,8 @@
       "<rootDir>/setupTests.ts"
     ]
   },
-  "pre-commit": ["coverage", "lint"]
+  "pre-commit": [
+    "coverage",
+    "lint"
+  ]
 }

--- a/public/stories.json
+++ b/public/stories.json
@@ -1,0 +1,27 @@
+[
+  {
+    "id":"1",
+    "title":"One",
+    "content":"This is the first story"
+  },
+  {
+    "id":"2",
+    "title":"Two",
+    "content":"This is the second story"
+  },
+  {
+    "id":"3",
+    "title":"Three",
+    "content":"This is the third story"
+  },
+  {
+    "id":"4",
+    "title":"Four",
+    "content":"This is the fourth story"
+  },
+  {
+    "id":"5",
+    "title":"Five",
+    "content":"This is the fifth story"
+  }
+]

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -6,10 +6,9 @@ import Container from './App.css';
 
 describe('App', () => {
   it('should render', () => {
-    const wrapper = mount(<App name="TestName" />);
+    const wrapper = mount(<App />);
 
     expect(wrapper).toBeDefined();
-    expect(wrapper.find(Container).text()).toEqual('TestName is a Rabbit!');
   });
 
   describe('styling', () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,24 +1,33 @@
 import React from 'react';
+import {
+  Link,
+  BrowserRouter as Router,
+  Route,
+  Switch,
+} from 'react-router-dom';
 import { ThemeProvider } from 'styled-components';
 import GlobalStyle from './styles/global';
 import ContainerSt from './App.css';
+import List from './components/list/List';
+import Story from './components/story/Story';
 
-interface IProps {
-  name?: string
-}
-
-const defaultTheme = {};
-
-const App = ({ name }: IProps) => (
-  <ThemeProvider theme={defaultTheme}>
-    <ContainerSt>
-      <h1>
-        {name} is a Rabbit!
-      </h1>
-    </ContainerSt>
-    <GlobalStyle />
-  </ThemeProvider>
+const App = () => (
+  <Router>
+    <ThemeProvider theme={{}}>
+      <ContainerSt>
+        <nav>
+          <Link to="/">List</Link>
+        </nav>
+        <Switch>
+          <Route path="/" exact component={List} />
+          <Route path="/story/:id">
+            <Story />
+          </Route>
+        </Switch>
+      </ContainerSt>
+      <GlobalStyle />
+    </ThemeProvider>
+  </Router>
 );
-
 
 export default App;

--- a/src/components/list/List.css.tsx
+++ b/src/components/list/List.css.tsx
@@ -1,0 +1,5 @@
+import styled from 'styled-components';
+
+export default styled.div`
+  display: block;
+`;

--- a/src/components/list/List.test.tsx
+++ b/src/components/list/List.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { shallow } from 'enzyme';
+import { mountWithRouter } from '../../testutils';
+import List from './List';
+import { IStory } from '../../interfaces/Story';
+
+const defaultProps = {
+  stories: [],
+};
+
+describe('List', () => {
+  it('should render', () => {
+    const wrapper = shallow(<List {...defaultProps} />);
+
+    expect(wrapper).toBeDefined();
+    expect(wrapper.find(Link)).toHaveLength(0);
+  });
+
+  it('should contain a list of links to stories', () => {
+    const stories: IStory[] = [
+      { id: '1', title: 'Test title one', content: 'Test content one' },
+      { id: '2', title: 'Test title two', content: 'Test content two' },
+    ];
+    const wrapper = mountWithRouter(<List stories={stories} />);
+
+    expect(wrapper.find(Link)).toHaveLength(2);
+    expect(wrapper.find(Link).at(0).text()).toEqual('Test title one');
+    expect(wrapper.find(Link).at(1).text()).toEqual('Test title two');
+  });
+});

--- a/src/components/list/List.tsx
+++ b/src/components/list/List.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { IStory } from '../../interfaces/Story';
+import ListSt from './List.css';
+
+interface IProps {
+  stories?: IStory[]
+}
+
+const List = ({ stories }: IProps) => (
+  <ListSt>
+    { stories?.map(({ id, title }) => <Link key={id} to={`/story/${id}`}>{title}</Link>) }
+  </ListSt>
+);
+
+export default List;

--- a/src/components/story/Story.css.tsx
+++ b/src/components/story/Story.css.tsx
@@ -1,0 +1,14 @@
+import styled from 'styled-components';
+import { colours } from '../../styles/vars';
+
+export default styled.div`
+  display: block;
+`;
+
+export const TitleSt = styled.h1`
+  color: ${colours.green};
+`;
+
+export const ContentSt = styled.div`
+  color: ${colours.blue};
+`;

--- a/src/components/story/Story.test.tsx
+++ b/src/components/story/Story.test.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Route } from 'react-router-dom';
+import { mountWithRouter } from '../../testutils';
+import Story from './Story';
+import StorySt, { TitleSt, ContentSt } from './Story.css';
+
+describe('Story', () => {
+  it('should render', () => {
+    const wrapper = mountWithRouter(
+      <Route>
+        <Story />
+      </Route>,
+    );
+
+    expect(wrapper).toBeDefined();
+    expect(wrapper.find(StorySt)).toHaveLength(1);
+    expect(wrapper.find(TitleSt)).toHaveLength(1);
+    expect(wrapper.find(ContentSt)).toHaveLength(1);
+  });
+});

--- a/src/components/story/Story.tsx
+++ b/src/components/story/Story.tsx
@@ -1,0 +1,27 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import StorySt, { TitleSt, ContentSt } from './Story.css';
+import { IStory } from '../../interfaces/Story';
+import stories from '../../stories';
+
+const Story = () => {
+  const { id } = useParams();
+  const [story, setStory] = useState();
+
+  useEffect(() => {
+    setStory(stories.find((item: IStory) => id === item.id));
+  }, [id]);
+
+  return (
+    <StorySt>
+      <TitleSt>
+        {story?.title || 'Title loading'}
+      </TitleSt>
+      <ContentSt>
+        {story?.content || 'Content loading'}
+      </ContentSt>
+    </StorySt>
+  );
+};
+
+export default Story;

--- a/src/interfaces/Story.ts
+++ b/src/interfaces/Story.ts
@@ -1,0 +1,5 @@
+export interface IStory {
+  id: string,
+  title: string,
+  content: string
+}

--- a/src/stories.ts
+++ b/src/stories.ts
@@ -1,0 +1,12 @@
+import { IStory } from './interfaces/Story';
+
+// TODO: fetch these from else where
+const stories: IStory[] = [
+  { id: '1', title: 'One', content: 'This is the first story' },
+  { id: '2', title: 'Two', content: 'This is the second story' },
+  { id: '3', title: 'Three', content: 'This is the third story' },
+  { id: '4', title: 'Four', content: 'This is the fourth story' },
+  { id: '5', title: 'Five', content: 'This is the fifth story' },
+];
+
+export default stories;

--- a/src/testutils.tsx
+++ b/src/testutils.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { BrowserRouter as Router } from 'react-router-dom';
+
+export const mountWithRouter = (children: any): any => mount(<Router>{children}</Router>);
+
+export default mountWithRouter;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,7 +13,7 @@ module.exports = {
   },
   output: {
     path: path.resolve(__dirname, 'build/'),
-    publicPath: '/build/',
+    publicPath: '/',
     filename: 'bundle.js',
   },
   resolve: {
@@ -23,6 +23,7 @@ module.exports = {
     contentBase: path.join(__dirname, 'public/'),
     port: 3000,
     publicPath: 'http://localhost:3000/build/',
+    historyApiFallback: true,
     hotOnly: true,
   },
 };


### PR DESCRIPTION
This PR focuses on routing and has the following changes:
- added `react-router-dom` to set up basic routing
- added skeleton views for a list of stories and a detail view
- added tests for most components and utilities
- added test utilities to mount components (with Enzyme) that contain routes
- updated webpack config for server side routing
- added pre-commit hooks