### PR TITLE
feat(server): add support for server side rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 
 # production
 /build
+/dist
 
 # misc
 .DS_Store

--- a/package-lock.json
+++ b/package-lock.json
@@ -9975,6 +9975,35 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
+    "node-dev": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/node-dev/-/node-dev-4.0.0.tgz",
+      "integrity": "sha512-XwaUAv2bb7Y9bhCT8dsel5XquRQczG5z4QYhh2otdUMuhRAgtDjFxZEKK4Tsa57vL2ye8ojfLIAZOTBx+Ui9zw==",
+      "dev": true,
+      "requires": {
+        "dateformat": "~1.0.4-1.2.3",
+        "dynamic-dedupe": "^0.3.0",
+        "filewatcher": "~3.0.0",
+        "minimist": "^1.1.3",
+        "node-notifier": "^5.4.0",
+        "resolve": "^1.0.0"
+      },
+      "dependencies": {
+        "node-notifier": {
+          "version": "5.4.3",
+          "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.3.tgz",
+          "integrity": "sha512-M4UBGcs4jeOK9CjTsYwkvH6/MzuUmGCyTW+kCY7uO+1ZVr0+FHGdPdIf5CCLqAaxnRrWidyoQlNkMIIVwbKB8Q==",
+          "dev": true,
+          "requires": {
+            "growly": "^1.3.0",
+            "is-wsl": "^1.1.0",
+            "semver": "^5.5.0",
+            "shellwords": "^0.1.1",
+            "which": "^1.3.0"
+          }
+        }
+      }
+    },
     "node-fetch": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
@@ -14192,6 +14221,12 @@
         "ansi-colors": "^3.0.0",
         "uuid": "^3.3.2"
       }
+    },
+    "webpack-node-externals": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/webpack-node-externals/-/webpack-node-externals-1.7.2.tgz",
+      "integrity": "sha512-ajerHZ+BJKeCLviLUUmnyd5B4RavLF76uv3cs6KNuO8W+HuQaEs0y0L7o40NQxdPy5w0pcv8Ew7yPUAQG0UdCg==",
+      "dev": true
     },
     "webpack-sources": {
       "version": "1.4.3",

--- a/package.json
+++ b/package.json
@@ -4,14 +4,13 @@
   "description": "A rabbit in the woods",
   "main": "index.js",
   "scripts": {
-    "dev-server": "ts-node-dev --transpile-only server/index.ts",
-    "dev-webpack": "webpack --watch --progress --colors --open --mode development",
-    "dev": "npm run dev-server & npm run dev-webpack",
+    "server": "node-dev ./dist/server/server.js",
+    "webpack": "webpack --watch --progress --colors --open --mode development",
     "test": "jest",
     "coverage": "jest --collect-coverage",
     "csslint": "stylelint './src/common/styles/**' './src/**/*.css.ts'",
     "clientlint": "eslint ./src/**/*.{ts,tsx}",
-    "serverlint": "eslint ./server/**/*.ts",
+    "serverlint": "eslint ./server/**/*.{ts,tsx}",
     "lint": "npm run clientlint && npm run serverlint && npm run csslint"
   },
   "repository": {
@@ -49,16 +48,17 @@
     "eslint-plugin-react": "^7.18.3",
     "eslint-plugin-react-hooks": "^1.7.0",
     "jest": "^25.1.0",
+    "node-dev": "^4.0.0",
     "pre-commit": "^1.2.2",
     "redux-mock-store": "^1.5.4",
     "stylelint": "^13.2.0",
     "stylelint-config-standard": "^20.0.0",
     "ts-jest": "^25.2.1",
     "ts-node": "^8.8.1",
-    "ts-node-dev": "^1.0.0-pre.44",
     "typescript": "^3.8.3",
     "webpack": "^4.41.6",
-    "webpack-cli": "^3.3.11"
+    "webpack-cli": "^3.3.11",
+    "webpack-node-externals": "^1.7.2"
   },
   "dependencies": {
     "@types/enzyme": "^3.10.5",

--- a/public/index.html
+++ b/public/index.html
@@ -7,6 +7,7 @@
   </head>
   <body>
     <div id="root"></div>
+    <script>PRELOADED_STATE</script>
     <script src="/bundle.js"></script>
   </body>
 </html>

--- a/server/IndexComponent.spec.tsx
+++ b/server/IndexComponent.spec.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Request } from 'express';
+import { shallow } from 'enzyme';
+import { createMockStore } from 'common/utils';
+import IndexComponent, { IProps } from './IndexComponent';
+
+const defaultProps: IProps = {
+  context: {},
+  req: {} as Request,
+  store: createMockStore([]),
+};
+
+describe('IndexComponent tests', () => {
+  it('should render the component', () => {
+    const wrapper = shallow(<IndexComponent {...defaultProps} />);
+
+    expect(wrapper).toBeDefined();
+  });
+});

--- a/server/IndexComponent.tsx
+++ b/server/IndexComponent.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Store } from 'redux';
+import { Request } from 'express';
+import { StaticRouter } from 'react-router-dom';
+import { Provider } from 'react-redux';
+import App from '../src/App';
+
+export interface IProps {
+  context: any,
+  req: Request,
+  store: Store,
+}
+
+export const IndexComponent = ({ context, req, store }: IProps) => (
+  <Provider store={store}>
+    <StaticRouter location={req.url} context={context}>
+      <App />
+    </StaticRouter>
+  </Provider>
+);
+
+export default IndexComponent;

--- a/server/controllers/AssetsController.spec.ts
+++ b/server/controllers/AssetsController.spec.ts
@@ -11,9 +11,8 @@ describe('AssetsController tests', () => {
 
     await new AssetsController();
 
-    expect(spyGet).toHaveBeenCalledTimes(2);
+    expect(spyGet).toHaveBeenCalledTimes(1);
     expect(spyGet.mock.calls[0][0]).toEqual('/:file.js');
-    expect(spyGet.mock.calls[1][0]).toEqual('*');
   });
 
   it('should deliver scripts', async () => {
@@ -39,29 +38,6 @@ describe('AssetsController tests', () => {
     expect(spySendFile.mock.calls[0][1]).toEqual({
       headers: {
         'Content-Type': 'application/x-javascript',
-      },
-    });
-  });
-
-  it('should deliver all other content', async () => {
-    const spySendFile = jest.fn();
-    const spyStatus = jest.fn().mockReturnValue({
-      sendFile: spySendFile,
-    });
-    const req: Request = {} as any;
-    const res: Response = {
-      status: spyStatus,
-    } as any;
-
-    await new AssetsController().allOthers(req, res);
-
-    expect(spyStatus).toHaveBeenCalledTimes(1);
-    expect(spyStatus.mock.calls[0][0]).toEqual(200);
-    expect(spySendFile).toHaveBeenCalledTimes(1);
-    expect(spySendFile.mock.calls[0][0]).toContain('/public/index.html');
-    expect(spySendFile.mock.calls[0][1]).toEqual({
-      headers: {
-        'Content-Type': 'text/html; charset=utf-8',
       },
     });
   });

--- a/server/controllers/AssetsController.ts
+++ b/server/controllers/AssetsController.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import { IBaseController } from '../common/interfaces';
 
 class AssetsController implements IBaseController {
-  private baseFilePath: string = path.resolve(__dirname, '../../');
+  private baseFilePath: string = path.resolve(__dirname, '../../public');
 
   public router = Router();
 
@@ -11,18 +11,18 @@ class AssetsController implements IBaseController {
     this.initRoutes();
   }
 
-  initRoutes() {
+  initRoutes = () => {
     this.router.get('/:file.js', this.scripts);
-    this.router.get('*', this.allOthers);
   }
 
   scripts = (req: Request, res: Response): void => {
     const { params: { file } } = req;
+    const filePath: string = `${this.baseFilePath}/${file}.js`;
 
     res
       .status(200)
       .sendFile(
-        `${this.baseFilePath}/public/${file}.js`,
+        filePath,
         {
           headers: {
             'Content-Type': 'application/x-javascript',
@@ -30,19 +30,6 @@ class AssetsController implements IBaseController {
         },
       );
   }
-
-  allOthers = (req: Request, res: Response): void => {
-    res
-      .status(200)
-      .sendFile(
-        `${this.baseFilePath}/public/index.html`,
-        {
-          headers: {
-            'Content-Type': 'text/html; charset=utf-8',
-          },
-        },
-      );
-  };
 }
 
 export default AssetsController;

--- a/server/controllers/SSRController.spec.ts
+++ b/server/controllers/SSRController.spec.ts
@@ -1,0 +1,127 @@
+import express, { Request, Response, Router } from 'express';
+import fs from 'fs';
+import createStoreWithPreloadedState from '../../src/common/store';
+import * as listActions from '../../src/components/list/actions';
+import * as storyActions from '../../src/components/story/actions';
+import IndexComponent from '../IndexComponent';
+import SSRController from './SSRController';
+
+jest.mock('../../src/common/store');
+jest.mock('../IndexComponent');
+
+describe('SSRController tests', () => {
+  const spyDispatch = jest.fn();
+  const spyGetState = jest.fn();
+
+  IndexComponent.mockReturnValue('div');
+
+  createStoreWithPreloadedState.mockReturnValue({
+    dispatch: spyDispatch,
+    getState: spyGetState,
+  });
+
+  afterEach(() => {
+    spyDispatch.mockClear();
+    spyGetState.mockClear();
+  });
+
+  afterAll(() => {
+    IndexComponent.mockReset();
+    createStoreWithPreloadedState.mockReset();
+  });
+
+  it('should initialise the routes and set up the redux store', async () => {
+    const spyGet = jest.fn() as jest.MockedFunction<typeof Router>;
+
+    jest.spyOn(express, 'Router').mockReturnValue({
+      get: spyGet,
+    } as any);
+
+    await new SSRController();
+    expect(spyGet).toHaveBeenCalledTimes(2);
+    expect(spyGet).toHaveBeenNthCalledWith(1, '/story/:slug', expect.any(Function), expect.any(Function));
+    expect(spyGet).toHaveBeenNthCalledWith(2, '/', expect.any(Function), expect.any(Function));
+  });
+
+  it('should dispatch to fetch stories and call next', async () => {
+    const spyFetchStories = jest.spyOn(listActions, 'fetchStories');
+    const spyNext = jest.fn();
+
+    await new SSRController().reduxFetchStories({} as Request, {} as Response, spyNext);
+    expect(spyDispatch).toHaveBeenCalledTimes(1);
+    expect(spyFetchStories).toHaveBeenCalledTimes(1);
+    expect(spyNext).toHaveBeenCalledTimes(1);
+
+    spyFetchStories.mockReset();
+  });
+
+  it('should dispatch to fetch a story and call next', async () => {
+    const spyFetchStory = jest.spyOn(storyActions, 'fetchStory');
+    const spyNext = jest.fn();
+
+    await new SSRController().reduxFetchStory(
+      {
+        params: {
+          slug: 'test-story',
+        },
+      } as any,
+      {} as Response,
+      spyNext,
+    );
+    expect(spyDispatch).toHaveBeenCalledTimes(1);
+    expect(spyFetchStory).toHaveBeenCalledTimes(1);
+    expect(spyFetchStory).toHaveBeenCalledWith('test-story');
+    expect(spyNext).toHaveBeenCalledTimes(1);
+
+    spyFetchStory.mockReset();
+  });
+
+  it('should send SSR rendered content', async () => {
+    const spyReadFile = jest.spyOn(fs, 'readFile').mockImplementation(
+      (indexPath: string, charset: string, cb: Function): void => {
+        cb(null, '<div id="root"><script>PRELOADED_STATE</script></div>');
+      },
+    );
+    const spySend = jest.fn();
+    const spyStatus = jest.fn().mockReturnValue({
+      send: spySend,
+    });
+    const res: Response = {
+      status: spyStatus,
+    } as any;
+    const expected = '<div id="root"><script>window.__PRELOADED_STATE__ = {};</script></div>';
+
+    spyGetState.mockResolvedValue({ test: 'state' });
+
+    await new SSRController().renderSSR({} as Request, res);
+    expect(spyStatus).toHaveBeenCalled();
+    expect(spyStatus).toHaveBeenCalledWith(200);
+    expect(spySend).toHaveBeenCalled();
+    expect(spySend).toHaveBeenCalledWith(expected);
+
+    spyReadFile.mockReset();
+  });
+
+  it('should fail to render content and return an error', async () => {
+    const spyReadFile = jest.spyOn(fs, 'readFile').mockImplementation(
+      (indexPath: string, charset: string, cb: Function): void => {
+        cb('dummy-error');
+      },
+    );
+    const spyJson = jest.fn();
+    const spyStatus = jest.fn().mockReturnValue({
+      json: spyJson,
+    });
+    const res: Response = {
+      status: spyStatus,
+    } as any;
+
+    await new SSRController().renderSSR({} as Request, res);
+    expect(spyStatus).toHaveBeenCalled();
+    expect(spyStatus).toHaveBeenCalledWith(500);
+    expect(spyJson).toHaveBeenCalled();
+    expect(spyJson).toHaveBeenCalledWith({ error: 'dummy-error' });
+
+    spyReadFile.mockReset();
+  });
+});

--- a/server/controllers/SSRController.ts
+++ b/server/controllers/SSRController.ts
@@ -1,0 +1,74 @@
+import React from 'react';
+import { Store } from 'redux';
+import { renderToString } from 'react-dom/server';
+import {
+  NextFunction, Request, Response, Router,
+} from 'express';
+import fs from 'fs';
+import path from 'path';
+import IndexComponent from '../IndexComponent';
+import createStoreWithPreloadedState from '../../src/common/store';
+import { fetchStories } from '../../src/components/list/actions';
+import { fetchStory } from '../../src/components/story/actions';
+import { IBaseController } from '../common/interfaces';
+
+class SSRController implements IBaseController {
+  private baseFilePath: string = path.resolve(__dirname, '../../public');
+
+  private store: Store;
+
+  public router = Router();
+
+  constructor() {
+    this.store = createStoreWithPreloadedState();
+    this.initRoutes();
+  }
+
+  initRoutes = () => {
+    this.router.get('/story/:slug', this.reduxFetchStory, this.renderSSR);
+    this.router.get('/', this.reduxFetchStories, this.renderSSR);
+  }
+
+  reduxFetchStories = async (req: Request, res: Response, next: NextFunction): Promise<any> => {
+    await this.store.dispatch(fetchStories());
+    next();
+  };
+
+  reduxFetchStory = async (req: Request, res: Response, next: NextFunction): Promise<any> => {
+    const { slug } = req.params;
+
+    await this.store.dispatch(fetchStory(slug));
+    next();
+  }
+
+  renderSSR = async (req: Request, res: Response): Promise<any> => {
+    const context: any = {};
+    const preloadedState: any = this.store.getState();
+    const indexPath: string = `${this.baseFilePath}/index.html`;
+    const appElement = React.createElement(IndexComponent, { context, req, store: this.store });
+    const reactAppHtml: string = renderToString(appElement);
+    const preloadedStateJson: string = JSON.stringify(preloadedState).replace(/</g, '\\u003c');
+
+    fs.readFile(indexPath, 'utf-8', (error: any, data: string): any => {
+      if (error) {
+        return res.status(500).json({ error });
+      }
+
+      return res
+        .status(200)
+        .send(
+          data
+            .replace(
+              // eslint-disable-next-line quotes
+              `<div id="root"></div>`, `<div id="root">${reactAppHtml}</div>`,
+            )
+            .replace(
+              '<script>PRELOADED_STATE</script>',
+              `<script>window.__PRELOADED_STATE__ = ${preloadedStateJson};</script>`,
+            ),
+        );
+    });
+  }
+}
+
+export default SSRController;

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,5 +1,6 @@
 import App from './App';
 import AssetsController from './controllers/AssetsController';
+import SSRController from './controllers/SSRController';
 import StoriesController from './controllers/StoriesController';
 
 const app = new App({
@@ -7,6 +8,7 @@ const app = new App({
   controllers: [
     new StoriesController(),
     new AssetsController(),
+    new SSRController(),
   ],
 });
 

--- a/src/App.spec.tsx
+++ b/src/App.spec.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { shallow } from 'enzyme';
 import 'jest-styled-components';
 import App from './App';
 
 describe('App', () => {
   it('should render', () => {
-    const wrapper = mount(<App />);
+    const wrapper = shallow(<App />);
 
     expect(wrapper).toBeDefined();
   });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,17 +1,7 @@
 import React from 'react';
-import { applyMiddleware, combineReducers, createStore } from 'redux';
-import thunkMiddleware from 'redux-thunk';
-import { Provider } from 'react-redux';
-import {
-  BrowserRouter as Router,
-  Link,
-  Route,
-  Switch,
-} from 'react-router-dom';
+import { Link, Route, Switch } from 'react-router-dom';
 import { ThemeProvider } from 'styled-components';
 import { GlobalStyle } from 'common/styles';
-import listState from './components/list/reducer';
-import storyState from './components/story/reducer';
 import ConnectedList from './components/list/ConnectedList';
 import ConnectedStory from './components/story/ConnectedStory';
 import ContainerSt, {
@@ -21,35 +11,28 @@ import ContainerSt, {
   MainSt,
 } from './App.css';
 
-const rootReducer = combineReducers({ listState, storyState });
-const store = createStore(rootReducer, applyMiddleware(thunkMiddleware));
-
 const App = () => (
-  <Provider store={store}>
-    <Router>
-      <ThemeProvider theme={{}}>
-        <ContainerSt>
-          <HeaderSt>
-            <Link to="/">
-              <HeadingSt>
-                Ben
-              </HeadingSt>
-            </Link>
-          </HeaderSt>
-          <MainSt>
-            <Switch>
-              <Route path="/" exact component={ConnectedList} />
-              <Route path="/story/:slug">
-                <ConnectedStory />
-              </Route>
-            </Switch>
-          </MainSt>
-          <FooterSt />
-        </ContainerSt>
-        <GlobalStyle />
-      </ThemeProvider>
-    </Router>
-  </Provider>
+  <ThemeProvider theme={{}}>
+    <ContainerSt>
+      <HeaderSt>
+        <Link to="/">
+          <HeadingSt>
+            Ben
+          </HeadingSt>
+        </Link>
+      </HeaderSt>
+      <MainSt>
+        <Switch>
+          <Route path="/" exact component={ConnectedList} />
+          <Route path="/story/:slug">
+            <ConnectedStory />
+          </Route>
+        </Switch>
+      </MainSt>
+      <FooterSt />
+    </ContainerSt>
+    <GlobalStyle />
+  </ThemeProvider>
 );
 
 export default App;

--- a/src/common/store.ts
+++ b/src/common/store.ts
@@ -1,0 +1,17 @@
+/* istanbul ignore file */
+import { applyMiddleware, combineReducers, createStore } from 'redux';
+import thunkMiddleware from 'redux-thunk';
+import listState from '../components/list/reducer';
+import storyState from '../components/story/reducer';
+
+const rootReducer = combineReducers({
+  listState, storyState,
+});
+
+export const createStoreWithPreloadedState = (preloadedState?: any) => createStore(
+  rootReducer,
+  preloadedState,
+  applyMiddleware(thunkMiddleware),
+);
+
+export default createStoreWithPreloadedState;

--- a/src/common/utils/api.spec.ts
+++ b/src/common/utils/api.spec.ts
@@ -14,6 +14,7 @@ describe('api tests', () => {
 
     const response = await apiCall('/test/resource');
     const responseData = await response.json();
+
     expect(response.status).toEqual(200);
     expect(responseData).toEqual({ test: 'Works!' });
   });

--- a/src/common/utils/testutils.tsx
+++ b/src/common/utils/testutils.tsx
@@ -1,5 +1,7 @@
 /* istanbul ignore file */
 import React from 'react';
+import { Store } from 'redux';
+import { Provider } from 'react-redux';
 import { mount } from 'enzyme';
 import thunk from 'redux-thunk';
 import configureMockStore from 'redux-mock-store';
@@ -11,13 +13,19 @@ import {
 
 export type IReduxStateType = IListState | IStoryState;
 
-export const mountWithRouter = (children: any): any => mount(<Router>{children}</Router>);
-
-export const createMockStore = (reduxStates: IReduxStateType[]) => {
+export const createMockStore = (reduxStates: IReduxStateType[]): Store => {
   const middlewares = [thunk];
   const mockStore = configureMockStore(middlewares);
 
   return mockStore(reduxStates);
+};
+
+export const mountWithRouter = (children: any): any => mount(<Router>{children}</Router>);
+
+export const mountWithStore = (children: any): any => {
+  const store = createMockStore([]);
+
+  return mount(<Provider store={store}>{children}</Provider>);
 };
 
 export default mountWithRouter;

--- a/src/components/list/List.spec.tsx
+++ b/src/components/list/List.spec.tsx
@@ -2,10 +2,11 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { mount } from 'enzyme';
 import { mountWithRouter } from 'common/utils';
-import { IStory } from 'common/interfaces';
+import { FetchStoriesReturnType, IStory } from 'common/interfaces';
 import List from './List';
+import { ListItemSt } from './List.css';
 
-const noopPromise = (): Promise<any> => Promise.resolve();
+const noopPromise = (): FetchStoriesReturnType => Promise.resolve([]) as any;
 const defaultProps = {
   error: null,
   fetchStories: noopPromise,
@@ -23,13 +24,25 @@ describe('List', () => {
 
   it('should contain a list of links to stories', () => {
     const stories: IStory[] = [
-      { id: '1', title: 'Test title one', content: 'Test content one' },
-      { id: '2', title: 'Test title two', content: 'Test content two' },
+      {
+        id: '1', slug: 'test-one', title: 'Test title one', content: [],
+      },
+      {
+        id: '2', slug: 'test-two', title: 'Test title two', content: [],
+      },
     ];
     const wrapper = mountWithRouter(<List {...defaultProps} stories={stories} />);
 
     expect(wrapper.find(Link)).toHaveLength(2);
     expect(wrapper.find(Link).at(0).text()).toEqual('Test title one');
     expect(wrapper.find(Link).at(1).text()).toEqual('Test title two');
+  });
+
+  it('should render dummy stories while loading', () => {
+    const wrapper = mountWithRouter(<List {...defaultProps} pending />);
+
+    expect(wrapper.find(ListItemSt)).toHaveLength(5);
+    expect(wrapper.find(Link).at(0).text()).toEqual('Loading');
+    expect(wrapper.find(Link).at(4).text()).toEqual('Loading');
   });
 });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,20 @@
 import React from 'react';
+import { Store } from 'redux';
 import ReactDom from 'react-dom';
+import { BrowserRouter } from 'react-router-dom';
+import { Provider } from 'react-redux';
+import createStoreWithPreloadedState from 'common/store';
 import App from './App';
 
-ReactDom.render(<App name="Ben" />, document.getElementById('root'));
+// eslint-disable-next-line no-underscore-dangle
+const preloadedState = window.__PRELOADED_STATE__;
+const store: Store = createStoreWithPreloadedState(preloadedState);
+
+ReactDom.hydrate(
+  <Provider store={store}>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>,
+  </Provider>,
+  document.getElementById('root'),
+);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,7 @@
 const path = require('path');
+const nodeExternals = require('webpack-node-externals');
 
-module.exports = {
-  entry: path.resolve(__dirname, 'src'),
+const common = {
   module: {
     rules: [
       {
@@ -11,10 +11,6 @@ module.exports = {
       },
     ],
   },
-  output: {
-    path: path.resolve(__dirname, 'public/'),
-    filename: 'bundle.js',
-  },
   resolve: {
     alias: {
       common: path.resolve(__dirname, 'src/common/'),
@@ -23,3 +19,29 @@ module.exports = {
     extensions: ['.ts', '.tsx', '.js', '.json'],
   },
 };
+
+const front = {
+  ...common,
+  entry: path.resolve(__dirname, 'src'),
+  output: {
+    path: path.resolve(__dirname, 'public/'),
+    filename: 'bundle.js',
+  },
+  target: 'web',
+};
+
+const back = {
+  ...common,
+  entry: path.resolve(__dirname, 'server'),
+  externals: [nodeExternals()],
+  node: {
+    __dirname: true,
+  },
+  output: {
+    path: path.resolve(__dirname, 'dist/server'),
+    filename: 'server.js',
+  },
+  target: 'node',
+};
+
+module.exports = [front, back];


### PR DESCRIPTION
#### What is this ?
This PR adds support for server side rendering, whereby the content of this app is rendered (eventually ending up to be a string of HTML) on the server before being delivered to the client.

#### What is server side rendering and why is it important ?
Server side rendering is where the React application is rendered on the server (using various tools) so that the rendered HTML (having been generated) is sent to the client. This is beneficial for many reasons, including:
- better for screen readers and SEO, since all the content is readable when crawled by bots, many of which can't execute JS that generates content.
- better for performance, because we already have some of the rendered content delivered before a large JS payload needs to be delivered then executed.

#### How was this implemented
It was tricky (as SSR for client side apps generally is), but I was able to set up the server side controllers to load the React app, make calls to fetch content (Redux actions), and then finally render everything together and send it out using Express.

The Express middleware has a callback function `next()`, which allows you to wait until a task is complete before proceeding to a route. I used this and the Redux store dispatch functionality to fetch the data needed and populate it to the store.

Once that was done, this was sent to the client with `window.__PRELOADED_STATE__` and that way, the client could refresh its own stores and have them in sync with the server.

#### What is missing from this?
We still have a nasty flash of unstyled content (FOUC) when the page loads from the server. To fix this, I want to get SSR and styled-components playing well together.

I also have the server running as a separate process from Webpack, and ideally these should both be able to run at the same time, while waiting for the server build to finish before the server is started.

There is also a nasty trailing comma being returned with the HTML. I will create a separate fix for that.