### PR TITLE
feat(SSRController): basic implementation for server side syles added

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -13,6 +13,7 @@
   ],
   "plugins": [
     "@babel/proposal-class-properties",
-    "@babel/proposal-object-rest-spread"
+    "@babel/proposal-object-rest-spread",
+    "babel-plugin-styled-components"
   ]
 }

--- a/global.d.ts
+++ b/global.d.ts
@@ -1,0 +1,6 @@
+export {};
+declare global {
+  interface Window {
+    _PRELOADED_STATE_: any
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2080,18 +2080,6 @@
       "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
       "dev": true
     },
-    "@types/strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-FKjsOVbC6B7bdSB5CuzyHCkK69I=",
-      "dev": true
-    },
-    "@types/strip-json-comments": {
-      "version": "0.0.30",
-      "resolved": "https://registry.npmjs.org/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz",
-      "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==",
-      "dev": true
-    },
     "@types/styled-components": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@types/styled-components/-/styled-components-5.0.1.tgz",
@@ -13233,12 +13221,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "tree-kill": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
-      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
-      "dev": true
-    },
     "trim": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
@@ -13304,61 +13286,6 @@
         "make-error": "^1.1.1",
         "source-map-support": "^0.5.6",
         "yn": "3.1.1"
-      }
-    },
-    "ts-node-dev": {
-      "version": "1.0.0-pre.44",
-      "resolved": "https://registry.npmjs.org/ts-node-dev/-/ts-node-dev-1.0.0-pre.44.tgz",
-      "integrity": "sha512-M5ZwvB6FU3jtc70i5lFth86/6Qj5XR5nMMBwVxZF4cZhpO7XcbWw6tbNiJo22Zx0KfjEj9py5DANhwLOkPPufw==",
-      "dev": true,
-      "requires": {
-        "dateformat": "~1.0.4-1.2.3",
-        "dynamic-dedupe": "^0.3.0",
-        "filewatcher": "~3.0.0",
-        "minimist": "^1.1.3",
-        "mkdirp": "^0.5.1",
-        "node-notifier": "^5.4.0",
-        "resolve": "^1.0.0",
-        "rimraf": "^2.6.1",
-        "source-map-support": "^0.5.12",
-        "tree-kill": "^1.2.1",
-        "ts-node": "*",
-        "tsconfig": "^7.0.0"
-      },
-      "dependencies": {
-        "node-notifier": {
-          "version": "5.4.3",
-          "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.3.tgz",
-          "integrity": "sha512-M4UBGcs4jeOK9CjTsYwkvH6/MzuUmGCyTW+kCY7uO+1ZVr0+FHGdPdIf5CCLqAaxnRrWidyoQlNkMIIVwbKB8Q==",
-          "dev": true,
-          "requires": {
-            "growly": "^1.3.0",
-            "is-wsl": "^1.1.0",
-            "semver": "^5.5.0",
-            "shellwords": "^0.1.1",
-            "which": "^1.3.0"
-          }
-        }
-      }
-    },
-    "tsconfig": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
-      "integrity": "sha512-vZXmzPrL+EmC4T/4rVlT2jNVMWCi/O4DIiSj3UHg1OE5kCKbk4mfrXc6dZksLgRM/TZlKnousKH9bbTazUWRRw==",
-      "dev": true,
-      "requires": {
-        "@types/strip-bom": "^3.0.0",
-        "@types/strip-json-comments": "0.0.30",
-        "strip-bom": "^3.0.0",
-        "strip-json-comments": "^2.0.0"
-      },
-      "dependencies": {
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-          "dev": true
-        }
       }
     },
     "tslib": {

--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta charset="UTF-8" />
     <title>Ben</title>
+    <style type="text/css"></style>
   </head>
   <body>
     <div id="root"></div>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-underscore-dangle */
 import React from 'react';
 import { Store } from 'redux';
 import ReactDom from 'react-dom';
@@ -6,15 +7,16 @@ import { Provider } from 'react-redux';
 import createStoreWithPreloadedState from 'common/store';
 import App from './App';
 
-// eslint-disable-next-line no-underscore-dangle
-const preloadedState = window.__PRELOADED_STATE__;
+const preloadedState = window._PRELOADED_STATE_;
 const store: Store = createStoreWithPreloadedState(preloadedState);
+
+delete window._PRELOADED_STATE_;
 
 ReactDom.hydrate(
   <Provider store={store}>
     <BrowserRouter>
       <App />
-    </BrowserRouter>,
+    </BrowserRouter>
   </Provider>,
   document.getElementById('root'),
 );


### PR DESCRIPTION
#### What is this?
This PR adds support for server side rendered styled-components. This means that when the app is rendered on the server, the correct styles are generated and delivered, so the website does not have this ugly flash of unstyled content when it is initially loaded?

#### How was this done?
The SSRController (which renders the app server side and delivers the html) was modified so that the styles could be pulled out of the main React component for the app (in this case the `<IndexComponent />`. The styles are collected and then output into the generated html.

With the CSS passed in line, the app now looks like it should, and we don't have to wait for re-hydration for the look and feel to take shape.

This is achieved using industry standard practices (follow the guides given by the vendors of the tools we use) and test coverage remains at 100%.