### PR TITLE
refactor: refactor webpack config to improve bundle size

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,8 +36,10 @@ module.exports = {
   settings: {
     'import/resolver': {
       node: {
-        extensions: ['.js', '.jsx', '.ts', '.tsx', '.json'],
-        paths: ['./src']
+        moduleDirectory: ['node_modules', 'src', 'server'],
+      },
+      webpack: {
+        config: 'webpack.common.js'
       }
     }
   }

--- a/.gitignore
+++ b/.gitignore
@@ -7,12 +7,10 @@
 /coverage
 
 # production
-/build
 /dist
 
 # misc
 .DS_Store
-public/bundle.js
 
 npm-debug.log*
 yarn-debug.log*

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,12 +29,15 @@ We should have a simple set of dependencies that are well supported and adhere t
 
 ## What we have
 - full test coverage and reporting
+- code splitting and separate bundle configuration for webpack
 - code lint tools
 - basic REST server to serve assets and content
 - better path aliasing for module imports
+- implemented server side rendering
 
 ## Nice to have
-- implement server side rendering
 - use Redux Saga
 - use Storybook for component rendering/documentation
 - production bundling and CI flow
+- progressive web app with offline capability
+- improved SEO performance

--- a/package-lock.json
+++ b/package-lock.json
@@ -2487,6 +2487,12 @@
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
       "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ=="
     },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "dev": true
+    },
     "ansi-colors": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
@@ -2604,6 +2610,12 @@
       "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM=",
       "dev": true
     },
+    "array-find": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-find/-/array-find-1.0.0.tgz",
+      "integrity": "sha1-bI4obRHtdoMn+OYuzuhzU8o+eLg=",
+      "dev": true
+    },
     "array-find-index": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
@@ -2670,6 +2682,12 @@
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+      "dev": true
+    },
     "asn1": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
@@ -2727,6 +2745,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
+    },
+    "ast-types": {
+      "version": "0.9.6",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.6.tgz",
+      "integrity": "sha1-ECyenpAF0+fjgpvwxPok7oYu6bk=",
+      "dev": true
     },
     "ast-types-flow": {
       "version": "0.0.7",
@@ -3004,6 +3028,12 @@
           }
         }
       }
+    },
+    "base62": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/base62/-/base62-1.2.8.tgz",
+      "integrity": "sha512-V6YHUbjLxN1ymqNLb1DPHoU1CpfdL7d2YTIp5W3U4hhoG4hhxNmsFDs66M9EXxBiSEke5Bt5dwdfMwwZF70iLA==",
+      "dev": true
     },
     "base64-js": {
       "version": "1.3.1",
@@ -3667,6 +3697,44 @@
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
     },
+    "commoner": {
+      "version": "0.10.8",
+      "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.8.tgz",
+      "integrity": "sha1-NPw2cs0kOT6LtH5wyqApOBH08sU=",
+      "dev": true,
+      "requires": {
+        "commander": "^2.5.0",
+        "detective": "^4.3.1",
+        "glob": "^5.0.15",
+        "graceful-fs": "^4.1.2",
+        "iconv-lite": "^0.4.5",
+        "mkdirp": "^0.5.0",
+        "private": "^0.1.6",
+        "q": "^1.1.2",
+        "recast": "^0.11.17"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "dev": true
+        },
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "dev": true,
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
+      }
+    },
     "component-emitter": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
@@ -3790,6 +3858,12 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
+    },
+    "core-js": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+      "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+      "dev": true
     },
     "core-js-compat": {
       "version": "3.6.4",
@@ -4025,6 +4099,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
       "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
+      "dev": true
+    },
+    "d3": {
+      "version": "3.5.17",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-3.5.17.tgz",
+      "integrity": "sha1-vEZ0gAQ3iyGjYMn8fPUjF5B2L7g=",
       "dev": true
     },
     "damerau-levenshtein": {
@@ -4339,6 +4419,12 @@
         }
       }
     },
+    "defined": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+      "dev": true
+    },
     "del": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/del/-/del-4.1.1.tgz",
@@ -4395,6 +4481,24 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
       "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw=="
+    },
+    "detective": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/detective/-/detective-4.7.1.tgz",
+      "integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
+      "dev": true,
+      "requires": {
+        "acorn": "^5.2.1",
+        "defined": "^1.0.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "5.7.4",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+          "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
+          "dev": true
+        }
+      }
     },
     "diff": {
       "version": "4.0.2",
@@ -4645,6 +4749,16 @@
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
       "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
       "dev": true
+    },
+    "envify": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/envify/-/envify-3.4.1.tgz",
+      "integrity": "sha1-1xIjKejfFoi6dxsSUBkXyc5cvOg=",
+      "dev": true,
+      "requires": {
+        "jstransform": "^11.0.3",
+        "through": "~2.3.4"
+      }
     },
     "enzyme": {
       "version": "3.11.0",
@@ -4926,6 +5040,49 @@
       "requires": {
         "debug": "^2.6.9",
         "resolve": "^1.13.1"
+      }
+    },
+    "eslint-import-resolver-webpack": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-webpack/-/eslint-import-resolver-webpack-0.12.1.tgz",
+      "integrity": "sha512-O/sUAXk6GWrICiN8JUkkjdt9uZpqZHP+FVnTxtEILL6EZMaPSrnP4lGPSFwcKsv7O211maqq4Nz60+dh236hVg==",
+      "dev": true,
+      "requires": {
+        "array-find": "^1.0.0",
+        "debug": "^2.6.9",
+        "enhanced-resolve": "^0.9.1",
+        "find-root": "^1.1.0",
+        "has": "^1.0.3",
+        "interpret": "^1.2.0",
+        "lodash": "^4.17.15",
+        "node-libs-browser": "^1.0.0 || ^2.0.0",
+        "resolve": "^1.13.1",
+        "semver": "^5.7.1"
+      },
+      "dependencies": {
+        "enhanced-resolve": {
+          "version": "0.9.1",
+          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
+          "integrity": "sha1-TW5omzcl+GCQknzMhs2fFjW4ni4=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "memory-fs": "^0.2.0",
+            "tapable": "^0.1.8"
+          }
+        },
+        "memory-fs": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz",
+          "integrity": "sha1-8rslNovBIeORwlIN6Slpyu4KApA=",
+          "dev": true
+        },
+        "tapable": {
+          "version": "0.1.10",
+          "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz",
+          "integrity": "sha1-KcNXB8K3DlDQdIK10gLo7URtr9Q=",
+          "dev": true
+        }
       }
     },
     "eslint-module-utils": {
@@ -5569,6 +5726,19 @@
         "bser": "2.1.1"
       }
     },
+    "fbjs": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.6.1.tgz",
+      "integrity": "sha1-lja3cF9bqWhNRLcveDISVK/IYPc=",
+      "dev": true,
+      "requires": {
+        "core-js": "^1.0.0",
+        "loose-envify": "^1.0.0",
+        "promise": "^7.0.3",
+        "ua-parser-js": "^0.7.9",
+        "whatwg-fetch": "^0.9.0"
+      }
+    },
     "figgy-pudding": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
@@ -5652,6 +5822,12 @@
         "make-dir": "^2.0.0",
         "pkg-dir": "^3.0.0"
       }
+    },
+    "find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+      "dev": true
     },
     "find-up": {
       "version": "3.0.0",
@@ -9224,6 +9400,42 @@
         "verror": "1.10.0"
       }
     },
+    "jstransform": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/jstransform/-/jstransform-11.0.3.tgz",
+      "integrity": "sha1-CaeJk+CuTU70SH9hVakfYZDLQiM=",
+      "dev": true,
+      "requires": {
+        "base62": "^1.1.0",
+        "commoner": "^0.10.1",
+        "esprima-fb": "^15001.1.0-dev-harmony-fb",
+        "object-assign": "^2.0.0",
+        "source-map": "^0.4.2"
+      },
+      "dependencies": {
+        "esprima-fb": {
+          "version": "15001.1.0-dev-harmony-fb",
+          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz",
+          "integrity": "sha1-MKlHMDxrjV6VW+4rmbHSMyBqaQE=",
+          "dev": true
+        },
+        "object-assign": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
+          "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+          "dev": true,
+          "requires": {
+            "amdefine": ">=0.0.4"
+          }
+        }
+      }
+    },
     "jsx-ast-utils": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.2.3.tgz",
@@ -10941,6 +11153,15 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
+    "promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "dev": true,
+      "requires": {
+        "asap": "~2.0.3"
+      }
+    },
     "promise-inflight": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
@@ -11054,6 +11275,12 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+    },
+    "q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+      "dev": true
     },
     "qs": {
       "version": "6.7.0",
@@ -11342,6 +11569,26 @@
       "dev": true,
       "requires": {
         "util.promisify": "^1.0.0"
+      }
+    },
+    "recast": {
+      "version": "0.11.23",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.23.tgz",
+      "integrity": "sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM=",
+      "dev": true,
+      "requires": {
+        "ast-types": "0.9.6",
+        "esprima": "~3.1.0",
+        "private": "~0.1.5",
+        "source-map": "~0.5.0"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+          "dev": true
+        }
       }
     },
     "redent": {
@@ -13375,6 +13622,12 @@
       "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
       "dev": true
     },
+    "ua-parser-js": {
+      "version": "0.7.21",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.21.tgz",
+      "integrity": "sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ==",
+      "dev": true
+    },
     "unherit": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.3.tgz",
@@ -14149,6 +14402,15 @@
         "uuid": "^3.3.2"
       }
     },
+    "webpack-merge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.2.2.tgz",
+      "integrity": "sha512-TUE1UGoTX2Cd42j3krGYqObZbOD+xF7u28WB7tfUordytSjbWTIjK/8V0amkBfTYN4/pB/GIDlJZZ657BGG19g==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.15"
+      }
+    },
     "webpack-node-externals": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/webpack-node-externals/-/webpack-node-externals-1.7.2.tgz",
@@ -14169,6 +14431,36 @@
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
+    "webpack-visualizer-plugin": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/webpack-visualizer-plugin/-/webpack-visualizer-plugin-0.1.11.tgz",
+      "integrity": "sha1-uHcK2GtPZSYSxosbeCJT+vn4o04=",
+      "dev": true,
+      "requires": {
+        "d3": "^3.5.6",
+        "mkdirp": "^0.5.1",
+        "react": "^0.14.0",
+        "react-dom": "^0.14.0"
+      },
+      "dependencies": {
+        "react": {
+          "version": "0.14.9",
+          "resolved": "https://registry.npmjs.org/react/-/react-0.14.9.tgz",
+          "integrity": "sha1-kRCmSXxJ1EuhwO3TF67CnC4NkdE=",
+          "dev": true,
+          "requires": {
+            "envify": "^3.0.0",
+            "fbjs": "^0.6.1"
+          }
+        },
+        "react-dom": {
+          "version": "0.14.9",
+          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-0.14.9.tgz",
+          "integrity": "sha1-BQZKPc8PsYgKOyv8nVjFXY2fYpM=",
           "dev": true
         }
       }
@@ -14196,6 +14488,12 @@
       "requires": {
         "iconv-lite": "0.4.24"
       }
+    },
+    "whatwg-fetch": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-0.9.0.tgz",
+      "integrity": "sha1-DjaExsuZlbQ+/J3wPkw2XZX9nMA=",
+      "dev": true
     },
     "whatwg-mimetype": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "index.js",
   "scripts": {
     "server": "node-dev ./dist/server/server.js",
-    "webpack": "webpack --watch --progress --colors --open --mode development",
+    "webpack": "webpack --config webpack.dev.js --watch --progress --colors --open",
+    "clear": "rm -rf dist/app dist/server",
+    "build": "webpack --config webpack.prod.js",
     "test": "jest",
     "coverage": "jest --collect-coverage",
     "csslint": "stylelint './src/common/styles/**' './src/**/*.css.ts'",
@@ -43,6 +45,7 @@
     "enzyme-adapter-react-16": "^1.15.2",
     "eslint": "^6.8.0",
     "eslint-config-airbnb": "^18.0.1",
+    "eslint-import-resolver-webpack": "^0.12.1",
     "eslint-plugin-import": "^2.20.1",
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-react": "^7.18.3",
@@ -58,7 +61,9 @@
     "typescript": "^3.8.3",
     "webpack": "^4.41.6",
     "webpack-cli": "^3.3.11",
-    "webpack-node-externals": "^1.7.2"
+    "webpack-merge": "^4.2.2",
+    "webpack-node-externals": "^1.7.2",
+    "webpack-visualizer-plugin": "^0.1.11"
   },
   "dependencies": {
     "@types/enzyme": "^3.10.5",
@@ -91,7 +96,9 @@
     },
     "moduleNameMapper": {
       "^content/(.*)$": "<rootDir>/assets/content/$1",
-      "^common/(.*)$": "<rootDir>/src/common/$1"
+      "^app/common/(.*)$": "<rootDir>/src/common/$1",
+      "^app/components/(.*)$": "<rootDir>/src/components/$1",
+      "^server/common/(.*)$": "<rootDir>/server/common/$1"
     },
     "setupFilesAfterEnv": [
       "<rootDir>/setupTests.ts"

--- a/public/index.html
+++ b/public/index.html
@@ -9,6 +9,6 @@
   <body>
     <div id="root"></div>
     <script>PRELOADED_STATE</script>
-    <script src="/bundle.js"></script>
+    <script src="/main.bundle.js"></script>
   </body>
 </html>

--- a/server/App.ts
+++ b/server/App.ts
@@ -1,5 +1,5 @@
 import express, { Application } from 'express';
-import { IBaseController } from './common/interfaces';
+import { IBaseController } from 'server/common/interfaces';
 
 interface IApp {
   port: number;

--- a/server/IndexComponent.spec.tsx
+++ b/server/IndexComponent.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Request } from 'express';
 import { shallow } from 'enzyme';
-import { createMockStore } from 'common/utils';
+import { createMockStore } from 'app/common/utils/testutils';
 import IndexComponent, { IProps } from './IndexComponent';
 
 const defaultProps: IProps = {

--- a/server/controllers/AssetsController.spec.ts
+++ b/server/controllers/AssetsController.spec.ts
@@ -34,7 +34,7 @@ describe('AssetsController tests', () => {
     expect(spyStatus).toHaveBeenCalledTimes(1);
     expect(spyStatus.mock.calls[0][0]).toEqual(200);
     expect(spySendFile).toHaveBeenCalledTimes(1);
-    expect(spySendFile.mock.calls[0][0]).toContain('public/test.js');
+    expect(spySendFile.mock.calls[0][0]).toContain('dist/app/test.js');
     expect(spySendFile.mock.calls[0][1]).toEqual({
       headers: {
         'Content-Type': 'application/x-javascript',

--- a/server/controllers/AssetsController.ts
+++ b/server/controllers/AssetsController.ts
@@ -1,9 +1,9 @@
 import { Request, Response, Router } from 'express';
 import path from 'path';
-import { IBaseController } from '../common/interfaces';
+import { IBaseController } from 'server/common/interfaces';
 
 class AssetsController implements IBaseController {
-  private baseFilePath: string = path.resolve(__dirname, '../../public');
+  private baseFilePath: string = path.resolve(__dirname, '../../dist/app');
 
   public router = Router();
 

--- a/server/controllers/SSRController.spec.ts
+++ b/server/controllers/SSRController.spec.ts
@@ -1,9 +1,9 @@
 import fs from 'fs';
 import { renderToString } from 'react-dom/server';
 import express, { Request, Response, Router } from 'express';
-import createStoreWithPreloadedState from '../../src/common/store';
-import * as listActions from '../../src/components/list/actions';
-import * as storyActions from '../../src/components/story/actions';
+import createStoreWithPreloadedState from 'app/common/store';
+import * as listActions from 'app/components/list/actions';
+import * as storyActions from 'app/components/story/actions';
 import IndexComponent from '../IndexComponent';
 import SSRController from './SSRController';
 

--- a/server/controllers/SSRController.tsx
+++ b/server/controllers/SSRController.tsx
@@ -7,11 +7,11 @@ import {
 import fs from 'fs';
 import path from 'path';
 import { ServerStyleSheet } from 'styled-components';
+import createStoreWithPreloadedState from 'app/common/store';
+import { fetchStories } from 'app/components/list/actions';
+import { fetchStory } from 'app/components/story/actions';
+import { IBaseController } from 'server/common/interfaces';
 import IndexComponent from '../IndexComponent';
-import createStoreWithPreloadedState from '../../src/common/store';
-import { fetchStories } from '../../src/components/list/actions';
-import { fetchStory } from '../../src/components/story/actions';
-import { IBaseController } from '../common/interfaces';
 
 class SSRController implements IBaseController {
   private baseFilePath: string = path.resolve(__dirname, '../../public');

--- a/server/controllers/StoriesController.ts
+++ b/server/controllers/StoriesController.ts
@@ -1,6 +1,6 @@
 import { Request, Response, Router } from 'express';
 import path from 'path';
-import { IBaseController } from '../common/interfaces';
+import { IBaseController } from 'server/common/interfaces';
 
 class StoriesController implements IBaseController {
   private baseFilePath: string = path.resolve(__dirname, '../../');

--- a/src/App.css.tsx
+++ b/src/App.css.tsx
@@ -4,9 +4,9 @@ import {
   fontSizes,
   Heading,
   media,
-} from 'common/styles';
-import Header from './components/header/Header';
-import Footer from './components/footer/Footer';
+} from 'app/common/styles';
+import Header from 'app/components/header/Header';
+import Footer from 'app/components/footer/Footer';
 
 const ContainerSt = styled.div`
   display: grid;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { Link, Route, Switch } from 'react-router-dom';
 import { ThemeProvider } from 'styled-components';
-import { GlobalStyle } from 'common/styles';
-import ConnectedList from './components/list/ConnectedList';
-import ConnectedStory from './components/story/ConnectedStory';
+import { GlobalStyle } from 'app/common/styles';
+import ConnectedList from 'app/components/list/ConnectedList';
+import ConnectedStory from 'app/components/story/ConnectedStory';
 import ContainerSt, {
   FooterSt,
   HeaderSt,

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -1,5 +1,5 @@
 /* istanbul ignore file */
-import { IAppConfig } from 'common/interfaces';
+import { IAppConfig } from 'app/common/interfaces';
 
 export default {
   baseUrl: process.env.BASE_URL || 'http://localhost:3000',

--- a/src/common/store.ts
+++ b/src/common/store.ts
@@ -1,8 +1,8 @@
 /* istanbul ignore file */
 import { applyMiddleware, combineReducers, createStore } from 'redux';
 import thunkMiddleware from 'redux-thunk';
-import listState from '../components/list/reducer';
-import storyState from '../components/story/reducer';
+import listState from 'app/components/list/reducer';
+import storyState from 'app/components/story/reducer';
 
 const rootReducer = combineReducers({
   listState, storyState,

--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -1,3 +1,2 @@
 /* istanbul ignore file */
 export * from './api';
-export * from './testutils';

--- a/src/common/utils/testutils.tsx
+++ b/src/common/utils/testutils.tsx
@@ -9,7 +9,7 @@ import { BrowserRouter as Router } from 'react-router-dom';
 import {
   IListState,
   IStoryState,
-} from 'common/interfaces';
+} from 'app/common/interfaces';
 
 export type IReduxStateType = IListState | IStoryState;
 

--- a/src/components/footer/Footer.css.tsx
+++ b/src/components/footer/Footer.css.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { fontSizes } from 'common/styles';
+import { fontSizes } from 'app/common/styles';
 
 export const FooterSt = styled.footer`
   display: flex;

--- a/src/components/header/Header.spec.tsx
+++ b/src/components/header/Header.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { mountWithRouter } from 'common/utils';
+import { mountWithRouter } from 'app/common/utils/testutils';
 import Header from './Header';
 
 describe('Header tests', () => {

--- a/src/components/list/List.css.tsx
+++ b/src/components/list/List.css.tsx
@@ -1,6 +1,6 @@
 import styled, { css } from 'styled-components';
 import { Link } from 'react-router-dom';
-import { colours, fontSizes } from 'common/styles';
+import { colours, fontSizes } from 'app/common/styles';
 
 interface IListPropsSt {
   loading: number

--- a/src/components/list/List.spec.tsx
+++ b/src/components/list/List.spec.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { mount } from 'enzyme';
-import { mountWithRouter } from 'common/utils';
-import { FetchStoriesReturnType, IStory } from 'common/interfaces';
+import { mountWithRouter } from 'app/common/utils/testutils';
+import { FetchStoriesReturnType, IStory } from 'app/common/interfaces';
 import List from './List';
 import { ListItemSt } from './List.css';
 

--- a/src/components/list/List.tsx
+++ b/src/components/list/List.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { FetchStoriesReturnType, IStory } from 'common/interfaces';
+import { FetchStoriesReturnType, IStory } from 'app/common/interfaces';
 import ListSt, { ListItemSt, LinkSt } from './List.css';
 
 interface IProps {

--- a/src/components/list/actions.spec.ts
+++ b/src/components/list/actions.spec.ts
@@ -1,6 +1,6 @@
-import { createMockStore } from 'common/utils';
-import * as api from 'common/utils/api';
-import { IStory } from 'common/interfaces';
+import { createMockStore } from 'app/common/utils/testutils';
+import * as api from 'app/common/utils/api';
+import { IStory } from 'app/common/interfaces';
 import { fetchStories } from './actions';
 import {
   FETCH_STORIES_PENDING,

--- a/src/components/list/actions.ts
+++ b/src/components/list/actions.ts
@@ -1,6 +1,6 @@
 import { Response } from 'node-fetch';
-import { apiCall } from 'common/utils';
-import { FetchStoriesReturnType, IStory } from 'common/interfaces';
+import { apiCall } from 'app/common/utils';
+import { FetchStoriesReturnType, IStory } from 'app/common/interfaces';
 import {
   FETCH_STORIES_PENDING,
   FETCH_STORIES_SUCCESS,

--- a/src/components/list/reducer.spec.ts
+++ b/src/components/list/reducer.spec.ts
@@ -1,4 +1,4 @@
-import { IListState, IStory } from 'common/interfaces';
+import { IListState, IStory } from 'app/common/interfaces';
 import {
   FETCH_STORIES_PENDING,
   FETCH_STORIES_SUCCESS,

--- a/src/components/list/reducer.ts
+++ b/src/components/list/reducer.ts
@@ -1,4 +1,4 @@
-import { IListState } from 'common/interfaces';
+import { IListState } from 'app/common/interfaces';
 import {
   FETCH_STORIES_PENDING,
   FETCH_STORIES_SUCCESS,

--- a/src/components/story/Story.css.tsx
+++ b/src/components/story/Story.css.tsx
@@ -1,5 +1,5 @@
 import styled, { css } from 'styled-components';
-import { colours, SubHeading, Text } from 'common/styles';
+import { colours, SubHeading, Text } from 'app/common/styles';
 
 interface IParagraphStProps {
   redacted: boolean

--- a/src/components/story/Story.spec.tsx
+++ b/src/components/story/Story.spec.tsx
@@ -1,17 +1,17 @@
 import React from 'react';
 import { Route } from 'react-router-dom';
-import { mountWithRouter } from 'common/utils';
-import { IStory } from 'common/interfaces';
-import Story, { IProps } from './Story';
+import { mountWithRouter } from 'app/common/utils/testutils';
+import { IStory } from 'app/common/interfaces';
+import Story, { IProps, placeholderStory } from './Story';
 import { ChapterSt, ParagraphSt } from './Story.css';
 
 const noopPromise = (): Promise<any> => Promise.resolve();
 const defaultProps: IProps = {
   error: null,
   pending: false,
-  story: undefined,
-  fetchStory: noopPromise,
-  resetStory: noopPromise,
+  story: placeholderStory,
+  fetchStory: noopPromise as any,
+  resetStory: noopPromise as any,
 };
 
 describe('Story', () => {
@@ -38,7 +38,12 @@ describe('Story', () => {
   });
 
   it('shows the story', () => {
-    const story: IStory = { id: '1', title: 'Test', content: ['This is a test'] };
+    const story: IStory = {
+      id: '1',
+      title: 'Test',
+      slug: 'test',
+      content: ['This is a test'],
+    };
     const wrapper = mountWithRouter(
       <Route>
         <Story {...defaultProps} story={story} />

--- a/src/components/story/Story.tsx
+++ b/src/components/story/Story.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { Action } from 'redux';
 import { useParams } from 'react-router-dom';
-import { FetchStoryReturnType, IStory } from 'common/interfaces';
+import { FetchStoryReturnType, IStory } from 'app/common/interfaces';
 import StorySt, { ChapterSt, ParagraphSt } from './Story.css';
 
 export interface IProps {
@@ -12,7 +12,7 @@ export interface IProps {
   resetStory(): Action,
 }
 
-const placeholderStory: IStory = {
+export const placeholderStory: IStory = {
   id: '0',
   title: 'Loading...',
   slug: 'chapter-zero',

--- a/src/components/story/actions.spec.ts
+++ b/src/components/story/actions.spec.ts
@@ -1,6 +1,6 @@
-import { createMockStore } from 'common/utils';
-import * as api from 'common/utils/api';
-import { IStory } from 'common/interfaces';
+import { createMockStore } from 'app/common/utils/testutils';
+import * as api from 'app/common/utils/api';
+import { IStory } from 'app/common/interfaces';
 import { fetchStory, resetStory } from './actions';
 import {
   FETCH_STORY_PENDING,

--- a/src/components/story/actions.ts
+++ b/src/components/story/actions.ts
@@ -1,7 +1,7 @@
 import { Response } from 'node-fetch';
 import { Action } from 'redux';
-import { apiCall } from 'common/utils';
-import { FetchStoryReturnType, IStory } from 'common/interfaces';
+import { apiCall } from 'app/common/utils';
+import { FetchStoryReturnType, IStory } from 'app/common/interfaces';
 import {
   FETCH_STORY_PENDING,
   FETCH_STORY_SUCCESS,

--- a/src/components/story/reducer.spec.ts
+++ b/src/components/story/reducer.spec.ts
@@ -1,4 +1,4 @@
-import { IStory, IStoryState } from 'common/interfaces';
+import { IStory, IStoryState } from 'app/common/interfaces';
 import storyState, { defaultState } from './reducer';
 import {
   FETCH_STORY_PENDING,

--- a/src/components/story/reducer.ts
+++ b/src/components/story/reducer.ts
@@ -1,4 +1,4 @@
-import { IStoryState } from 'common/interfaces';
+import { IStoryState } from 'app/common/interfaces';
 import {
   FETCH_STORY_PENDING,
   FETCH_STORY_SUCCESS,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,10 +1,10 @@
 /* eslint-disable no-underscore-dangle */
 import React from 'react';
 import { Store } from 'redux';
-import ReactDom from 'react-dom';
+import { hydrate } from 'react-dom';
 import { BrowserRouter } from 'react-router-dom';
 import { Provider } from 'react-redux';
-import createStoreWithPreloadedState from 'common/store';
+import createStoreWithPreloadedState from 'app/common/store';
 import App from './App';
 
 const preloadedState = window._PRELOADED_STATE_;
@@ -12,7 +12,7 @@ const store: Store = createStoreWithPreloadedState(preloadedState);
 
 delete window._PRELOADED_STATE_;
 
-ReactDom.hydrate(
+hydrate(
   <Provider store={store}>
     <BrowserRouter>
       <App />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,9 @@
     "baseUrl": "./",
     "paths": {
       "content/*": ["assets/content/*"],
-      "common/*": ["src/common/*"]
+      "app/common/*": ["src/common/*"],
+      "app/components/*": ["src/components/*"],
+      "server/common/*": ["server/common/*"]
     },
     "target": "esnext",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
     "module": "commonjs",                       /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const nodeExternals = require('webpack-node-externals');
+const Visuaulizer = require('webpack-visualizer-plugin');
 
 const common = {
   module: {
@@ -7,30 +8,41 @@ const common = {
       {
         test: /\.(ts|js)x?$/,
         loader: 'babel-loader',
-        exclude: /(node_modules)/,
+        exclude: /node_modules/,
       },
     ],
   },
   resolve: {
     alias: {
-      common: path.resolve(__dirname, 'src/common/'),
-      content: path.resolve(__dirname, 'assets/content/'),
+      'app/common': path.resolve(__dirname, 'src/common/'),
+      'app/components': path.resolve(__dirname, 'src/components'),
+      'server/common': path.resolve(__dirname, 'server/common'),
     },
     extensions: ['.ts', '.tsx', '.js', '.json'],
   },
 };
 
-const front = {
+const client = {
   ...common,
   entry: path.resolve(__dirname, 'src'),
+  plugins: [
+    new Visuaulizer({
+      filename: './stats.html',
+    }),
+  ],
   output: {
-    path: path.resolve(__dirname, 'public/'),
-    filename: 'bundle.js',
+    path: path.resolve(__dirname, 'dist/app'),
+    filename: '[name].bundle.js',
+  },
+  optimization: {
+    splitChunks: {
+      chunks: 'all',
+    },
   },
   target: 'web',
 };
 
-const back = {
+const server = {
   ...common,
   entry: path.resolve(__dirname, 'server'),
   externals: [nodeExternals()],
@@ -44,4 +56,4 @@ const back = {
   target: 'node',
 };
 
-module.exports = [front, back];
+module.exports = [client, server];

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -1,0 +1,13 @@
+const merge = require('webpack-merge');
+const [client, server] = require('./webpack.common');
+
+const devclient = merge(client, {
+  mode: 'development',
+  devtool: 'inline-source-map',
+});
+
+const devserver = merge(server, {
+  mode: 'development',
+});
+
+module.exports = [devclient, devserver];

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -1,0 +1,13 @@
+const merge = require('webpack-merge');
+const [client, server] = require('./webpack.common');
+
+const devclient = merge(client, {
+  mode: 'production',
+  devtool: 'source-map',
+});
+
+const devserver = merge(server, {
+  mode: 'production',
+});
+
+module.exports = [devclient, devserver];


### PR DESCRIPTION
#### What is this?
This PR optimises the webpack set up, so that a much smaller payload is delivered for production bundles. The following changes describe this in more detail:

- Separate configurations have been created in webpack, which share a common base but a compressed bundle for release to production.
- By mistake, the test utilities that had been written for testing only, were inadvertently being included in development and production builds, such as enzyme. Correcting this reduced the bundle size considerably (from 750kb to 12kb).
- Path aliases for file imports have been tidied up a bit.